### PR TITLE
Sqoop - Branch 1.4.5

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -176,11 +176,11 @@
     <elseif>
       <equals arg1="${hadoopversion}" arg2="210" />
       <then>
-        <property name="hadoop.version" value="2.1.0-beta" />
-        <property name="hbase94.version" value="0.94.2" />
-        <property name="zookeeper.version" value="3.4.2" />
-        <property name="hadoop.version.full" value="2.1.0-beta" />
-        <property name="hcatalog.version" value="0.13.0" />
+        <property name="hadoop.version" value="2.6.0" />
+        <property name="hbase95.version" value="1.0.0" />
+        <property name="zookeeper.version" value="3.4.6" />
+        <property name="hadoop.version.full" value="2.6.0" />
+        <property name="hcatalog.version" value="1.1.0" />
         <property name="hbasecompatprofile" value="2" />
         <property name="avrohadoopprofile" value="2" />
       </then>

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -18,7 +18,7 @@
 # This properties file lists the versions of the various artifacts we use.
 # It drives ivy and the generation of a maven POM
 
-avro.version=1.7.5
+avro.version=1.7.7
 
 checkstyle.version=5.0
 

--- a/src/java/org/apache/sqoop/mapreduce/AvroOutputFormat.java
+++ b/src/java/org/apache/sqoop/mapreduce/AvroOutputFormat.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 
 import static org.apache.avro.file.DataFileConstants.DEFAULT_SYNC_INTERVAL;
 import static org.apache.avro.file.DataFileConstants.DEFLATE_CODEC;
-import static org.apache.avro.mapred.AvroOutputFormat.DEFAULT_DEFLATE_LEVEL;
+import static org.apache.avro.file.CodecFactory.DEFAULT_DEFLATE_LEVEL;
 import static org.apache.avro.mapred.AvroOutputFormat.DEFLATE_LEVEL_KEY;
 import static org.apache.avro.mapred.AvroOutputFormat.EXT;
 import static org.apache.avro.mapred.AvroOutputFormat.SYNC_INTERVAL_KEY;


### PR DESCRIPTION
Changes made are : 
- Used latest versions of packages (hadoop-2.6.0, zookeeper-3.4.6, hbase-1.0.0, hive/hcatalog - 1.1.0, avro-1.7.7)
- hbase94.version is made hbase95.version in hadoopprofile=210 because the required hbase related test jars were defined in ivy.xml for hbase95 only. 
- As there is a change in Avro's API from 1.7.5 to 1.7.7, had to change an import statement in AvroOutputFormat.java. 
